### PR TITLE
Refactor ClientActiveRequests out of dlink

### DIFF
--- a/src/ClientActiveRequests.cc
+++ b/src/ClientActiveRequests.cc
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 1996-2023 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#include "squid.h"
+
+#include "ClientActiveRequests.h"
+#include "dlink.h"
+
+ClientActiveRequests&
+ClientActiveRequests::Instance()
+{
+    static ClientActiveRequests instance;
+    return instance;
+}
+
+void
+ClientActiveRequests::MakeHead(dlink_node *m)
+{
+    dlinkDelete(m, ActiveRequests_);
+    dlinkAdd(m->data, m, ActiveRequests_);
+}
+
+void
+ClientActiveRequests::Add(ClientHttpRequest * r, dlink_node *m)
+{
+    dlinkAdd(r, m, ActiveRequests_);
+}
+
+void
+ClientActiveRequests::Delete(dlink_node *m)
+{
+    dlinkDelete(m, ActiveRequests_);
+}
+
+ClientActiveRequests::ClientActiveRequests()
+{
+    ActiveRequests_ = new dlink_list;
+}

--- a/src/ClientActiveRequests.h
+++ b/src/ClientActiveRequests.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 1996-2023 The Squid Software Foundation and contributors
+ *
+ * Squid software is distributed under GPLv2+ license and includes
+ * contributions from numerous individuals and organizations.
+ * Please see the COPYING and CONTRIBUTORS files for details.
+ */
+
+#ifndef SQUID_SRC_CLIENTACTIVEREQUESTS_H
+#define SQUID_SRC_CLIENTACTIVEREQUESTS_H
+
+class dlink_list;
+class dlink_node;
+class ClientHttpRequest;
+class StoreEntry;
+
+class ClientActiveRequests
+{
+    public:
+    static ClientActiveRequests &Instance();
+    void Add(ClientHttpRequest *, dlink_node *m);
+    void Delete(dlink_node *m);
+    void MakeHead(dlink_node *m);
+    // only use for iterating
+    dlink_list *GetActiveRequests() { return ActiveRequests_; };
+
+private:
+    ClientActiveRequests();
+    dlink_list *ActiveRequests_;
+};
+#endif /* SQUID_SRC_CLIENTACTIVEREQUESTS_H */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -208,6 +208,8 @@ squid_SOURCES = \
 	CachePeers.cc \
 	CachePeers.h \
 	ClientInfo.h \
+	ClientActiveRequests.cc \
+	ClientActiveRequests.h \
 	ClientRequestContext.h \
 	CollapsedForwarding.cc \
 	CollapsedForwarding.h \
@@ -1771,6 +1773,8 @@ tests_test_http_range_SOURCES = \
 	CachePeer.h \
 	CachePeers.cc \
 	CachePeers.h \
+	ClientActiveRequests.cc \
+	ClientActiveRequests.h \
 	ClientInfo.h \
 	tests/stub_CollapsedForwarding.cc \
 	ConfigOption.cc \
@@ -2158,6 +2162,8 @@ tests_testHttpRequest_SOURCES = \
 	CachePeer.h \
 	CachePeers.cc \
 	CachePeers.h \
+	ClientActiveRequests.cc \
+	ClientActiveRequests.h \
 	ClientInfo.h \
 	tests/stub_CollapsedForwarding.cc \
 	ConfigOption.cc \
@@ -2457,6 +2463,8 @@ tests_testCacheManager_SOURCES = \
 	CachePeer.h \
 	CachePeers.cc \
 	CachePeers.h \
+	ClientActiveRequests.cc \
+	ClientActiveRequests.h \
 	ClientInfo.h \
 	tests/stub_CollapsedForwarding.cc \
 	ConfigOption.cc \

--- a/src/client_side_reply.h
+++ b/src/client_side_reply.h
@@ -90,7 +90,6 @@ private:
     void fillChecklist(ACLFilledChecklist &) const override;
 
     clientStreamNode *getNextNode() const;
-    void makeThisHead();
     bool errorInStream(const StoreIOBuffer &result) const;
     bool matchesStreamBodyBuffer(const StoreIOBuffer &) const;
     void sendStreamError(StoreIOBuffer const &result);

--- a/src/client_side_request.cc
+++ b/src/client_side_request.cc
@@ -24,6 +24,7 @@
 #include "client_side.h"
 #include "client_side_reply.h"
 #include "client_side_request.h"
+#include "ClientActiveRequests.h"
 #include "ClientRequestContext.h"
 #include "clientStream.h"
 #include "comm/Connection.h"
@@ -148,7 +149,7 @@ ClientHttpRequest::ClientHttpRequest(ConnStateData * aConn) :
         }
 #endif
     }
-    dlinkAdd(this, &active, &ClientActiveRequests);
+    ClientActiveRequests::Instance().Add(this, &active);
 }
 
 /*
@@ -265,7 +266,7 @@ ClientHttpRequest::~ClientHttpRequest()
     cbdataReferenceDone(conn_);
 
     /* moving to the next connection is handled by the context free */
-    dlinkDelete(&active, &ClientActiveRequests);
+    ClientActiveRequests::Instance().Delete(&active);
 }
 
 /**

--- a/src/dlink.cc
+++ b/src/dlink.cc
@@ -9,8 +9,6 @@
 #include "squid.h"
 #include "dlink.h"
 
-dlink_list ClientActiveRequests;
-
 void
 dlinkAdd(void *data, dlink_node * m, dlink_list * list)
 {

--- a/src/dlink.h
+++ b/src/dlink.h
@@ -27,8 +27,6 @@ public:
     dlink_node *tail = nullptr;
 };
 
-extern dlink_list ClientActiveRequests;
-
 void dlinkAdd(void *data, dlink_node *, dlink_list *);
 void dlinkAddAfter(void *, dlink_node *, dlink_node *, dlink_list *);
 void dlinkAddTail(void *data, dlink_node *, dlink_list *);

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -13,6 +13,7 @@
 #include "CacheDigest.h"
 #include "CachePeer.h"
 #include "CachePeers.h"
+#include "ClientActiveRequests.h"
 #include "client_side.h"
 #include "client_side_request.h"
 #include "comm/Connection.h"
@@ -1262,10 +1263,6 @@ statInit(void)
 
     eventAdd("statAvgTick", statAvgTick, nullptr, (double) COUNT_INTERVAL, 1);
 
-    ClientActiveRequests.head = nullptr;
-
-    ClientActiveRequests.tail = nullptr;
-
     statRegisterWithCacheManager();
 }
 
@@ -1774,7 +1771,7 @@ statClientRequests(StoreEntry * s)
     StoreEntry *e;
     char buf[MAX_IPSTRLEN];
 
-    for (i = ClientActiveRequests.head; i; i = i->next) {
+    for (i = ClientActiveRequests::Instance().GetActiveRequests()->head; i; i = i->next) {
         const char *p = nullptr;
         http = static_cast<ClientHttpRequest *>(i->data);
         assert(http);


### PR DESCRIPTION
ClientActiveRequests does not belong in dlink,
move it to its own file.

Implement a singleton to hold it, and API wrappers
to reduce source level coupling