### PR TITLE
Maintenance: refactor DigestFieldsLookupTable initialization

### DIFF
--- a/src/auth/digest/Config.cc
+++ b/src/auth/digest/Config.cc
@@ -80,9 +80,6 @@ DigestAttrs[] = {
     {nullptr, DIGEST_INVALID_ATTR}
 };
 
-LookupTable<http_digest_attr_type>
-DigestFieldsLookupTable(DIGEST_INVALID_ATTR, DigestAttrs);
-
 /*
  *
  * Nonce Functions
@@ -774,6 +771,7 @@ Auth::Digest::Config::decode(char const *proxy_auth, const HttpRequest *request,
         }
 
         /* find type */
+        static LookupTable<http_digest_attr_type> DigestFieldsLookupTable(DIGEST_INVALID_ATTR, DigestAttrs);
         const http_digest_attr_type t = DigestFieldsLookupTable.lookup(keyName);
 
         switch (t) {


### PR DESCRIPTION
Fix Coverity Scan defects cid-14554677:
Initialization or destruction order is unspecified