### PR TITLE
CI: cancel obsolete concurrent Github workflow runs

### DIFF
--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -16,6 +16,11 @@ on:
     # test PRs targeting this branch code
     branches: [ "master" ]
 
+concurrency:
+  # cancel old runs in case of push to same pr or branch
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   # empty except for pull_request events
   PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -21,7 +21,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-
 env:
   # empty except for pull_request events
   PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/quick.yaml
+++ b/.github/workflows/quick.yaml
@@ -21,6 +21,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+
 env:
   # empty except for pull_request events
   PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
If a new push happens to a branch or a Pr, it's pointless and wasteful
to keep running now-obsolete workflow runs; cancel them