### PR TITLE
Prep for v6.13

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -504,6 +504,7 @@ Thank you!
     Thomas Zajic <zlatko-github@zlatk0.net>
     Thomas-Martin Seck <tmseck@netcologne.de>
     Tianyin Xu <tixu@cs.ucsd.edu>
+    Tilman Heinrich <tilHeinrich@web.de>
     Tilmann Bubeck <t.bubeck@reinform.de>
     Tim Brown <squid-cache@machine.org.uk>
     Tim Starling <tstarling@wikimedia.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -3510,7 +3510,7 @@ Squid-2 ChangeLog of versions fully ported to Squid-3 follows.
 Changes to squid-2.6.STABLE22 (19 October 2008)
 
 	- Bug #2396: Correct the opening of the PF device file.
-	- Make --with-large-files and --with-build-envirnment=default play
+	- Make --with-large-files and --with-build-environment=default play
 	  nice together
 	- Workaround for Linux-2.6.24 & 2.6.25 netfiler_ipv4.h include header
 	  __u32 problem

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,25 @@
+Changes in squid-6.13 (31 Jan 2025):
+
+	- Bug 5352: Do not get stuck when RESPMOD is slower than read(2) 
+	- Bug 5405: Large uploads fill request buffer and die 
+	- Bug 5093: List http_port params that https_port/ftp_port lack 
+	- Bug 5311: clarify configuration byte units 
+	- Bug 5091: document that changes to workers require restart 
+	- Bug 5481: Fix GCC v14 build [-Wmaybe-uninitialized] 
+	- Nil request dereference in ACLExtUser and SourceDomainCheck ACLs 
+	- Refactor peerRefreshDNS() to clarify its (void*)1 logic 
+	- Fix GCC v14 [-Wanalyzer-null-dereference] warnings in Kerberos 
+	- Fix systemd startup sequence to require active Local Filesystem 
+	- ext_time_quota_acl: remove -l option 
+	- Portability: remove explicit check for libdl 
+	- Clarify --enable-ecap failure on missing shared library support 
+	- Fix syntax error in configure.ac
+	- Remove GNU'ism in release notes Makefile 
+	- Annotate PoolMalloc memory in valgrind builds 
+	- Display Linux variant at ./configure time 
+	- ... and some documentation updates
+	- ... and some CI improvements
+
 Changes in squid-6.12 (12 Oct 2024):
 
 	- Fix validation of Digest auth header parameters

--- a/configure.ac
+++ b/configure.ac
@@ -393,14 +393,6 @@ AS_IF([test "x$squid_opt_aufs_threads" != "x"],[
     [Defines how many threads aufs uses for I/O])
 ])
 
-## TODO check if this is necessary, LT_INIT does these checks
-SQUID_AUTO_LIB(dl,[dynamic linking],[LIBDL])
-AS_IF([test "x$with_dl" != "xno"],[
-  CXXFLAGS="$LIBDL_CFLAGS $CXXFLAGS"
-  LDFLAGS="$LIBDL_PATH $LDFLAGS"
-  AC_CHECK_LIB(dl, dlopen)
-])
-
 AC_DEFUN([LIBATOMIC_CHECKER],[
   AC_MSG_CHECKING(whether linking $1 -latomic works)
   AC_LINK_IFELSE([

--- a/configure.ac
+++ b/configure.ac
@@ -1043,7 +1043,7 @@ AC_MSG_NOTICE([HTCP support enabled: $enable_htcp])
 
 # Cryptograhic libraries
 SQUID_AUTO_LIB(nettle,[Nettle crypto],[LIBNETTLE])
-AS_IF(test "x$with_nettle" != "xno"],[
+AS_IF([test "x$with_nettle" != "xno"],[
   SQUID_STATE_SAVE(squid_nettle_state)
   PKG_CHECK_MODULES([LIBNETTLE],[nettle >= 3.4],[],[
     CPPFLAGS="$LIBNETTLE_CFLAGS $CPPFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -887,7 +887,7 @@ AC_ARG_ENABLE(ecap,
 dnl Perform configuration consistency checks for eCAP
 AS_IF([test "x$enable_ecap" != "xno"],[
   AS_IF([test "x$enable_shared" != "xyes"],[
-    AC_MSG_ERROR([eCAP support requires loadable modules. Please do not use --disable-shared with --enable-ecap.])
+    AC_MSG_ERROR([eCAP support requires loadable modules (i.e. --enable-shared or equivalent).])
   ])
 
   AS_IF([test -n "$PKG_CONFIG"],[

--- a/doc/release-notes/Makefile.am
+++ b/doc/release-notes/Makefile.am
@@ -10,7 +10,9 @@ if ENABLE_RELEASE_DOCS
 
 DOC= release-$(SQUID_RELEASE)
 
-%.sgml: %.sgml.in
+SUFFIXES= .sgml.in .sgml
+
+.sgml.in.sgml:
 	sed \
         -e "s%[@]SQUID_VERSION[@]%$(VERSION)%g" \
         -e "s%[@]SQUID_RELEASE[@]%$(SQUID_RELEASE)%g" \
@@ -18,18 +20,18 @@ DOC= release-$(SQUID_RELEASE)
         < $< >$@
 	test `grep -c "@SQUID" $@` -eq 0
 
-%.txt: %.sgml
+.sgml.txt:
 	linuxdoc -B txt --filter $<
 
-%.html: %.sgml
+.sgml.html:
 	linuxdoc -B html -T 2 --split=0 $<
 	perl -i -p -e "s%$@%%" $@
 	cp -p $@ $(top_builddir)/RELEASENOTES.html
 
-%.man: %.sgml
+.sgml.man:
 	linuxdoc -B txt --manpage $<
 
-%.info: %.sgml
+.sgml.info:
 	linuxdoc -B info $<
 
 dist-hook: $(DOC).html

--- a/src/acl/ExtUser.h
+++ b/src/acl/ExtUser.h
@@ -27,6 +27,7 @@ public:
     char const *typeString() const override;
     void parse() override;
     int match(ACLChecklist *checklist) override;
+    bool requiresRequest() const override { return true; }
     SBufList dump() const override;
     bool empty () const override;
 

--- a/src/acl/SourceDomain.cc
+++ b/src/acl/SourceDomain.cc
@@ -36,7 +36,11 @@ SourceDomainLookup::LookupDone(const char *, const Dns::LookupDetails &details, 
 {
     ACLFilledChecklist *checklist = Filled((ACLChecklist*)data);
     checklist->markSourceDomainChecked();
-    checklist->request->recordLookup(details);
+    if (checklist->request)
+        checklist->request->recordLookup(details);
+    else
+        debugs(28, 3, "no request to recordLookup()");
+
     checklist->resumeNonBlockingCheck(SourceDomainLookup::Instance());
 }
 

--- a/src/acl/external/kerberos_ldap_group/support_sasl.cc
+++ b/src/acl/external/kerberos_ldap_group/support_sasl.cc
@@ -202,16 +202,16 @@ void
 lutil_sasl_freedefs(
     void *defaults)
 {
-    lutilSASLdefaults *defs = (lutilSASLdefaults *) defaults;
+    if (const auto defs = static_cast<lutilSASLdefaults*>(defaults)) {
+        xfree(defs->mech);
+        xfree(defs->realm);
+        xfree(defs->authcid);
+        xfree(defs->passwd);
+        xfree(defs->authzid);
+        xfree(defs->resps);
 
-    xfree(defs->mech);
-    xfree(defs->realm);
-    xfree(defs->authcid);
-    xfree(defs->passwd);
-    xfree(defs->authzid);
-    xfree(defs->resps);
-
-    xfree(defs);
+        xfree(defs);
+    }
 }
 
 int

--- a/src/auth/negotiate/kerberos/negotiate_kerberos_pac.cc
+++ b/src/auth/negotiate/kerberos/negotiate_kerberos_pac.cc
@@ -202,6 +202,12 @@ getdomaingids(char *ad_groups, uint32_t DomainLogonId, char **Rids, uint32_t Gro
         return nullptr;
     }
 
+    if (!Rids) {
+        debug((char *) "%s| %s: ERR: Invalid RIDS list\n",
+              LogTime(), PROGRAM);
+        return nullptr;
+    }
+
     if (DomainLogonId!= 0) {
         uint8_t rev;
         uint64_t idauth;

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -2584,6 +2584,9 @@ DOC_START
 	The tls-cert= option is mandatory on HTTPS ports.
 
 	See http_port for a list of modes and options.
+	Not all http_port options are available for https_port.
+	Among the unavalable options:
+	- require-proxy-header
 DOC_END
 
 NAME: ftp_port
@@ -2648,6 +2651,9 @@ DOC_START
 
 	Other http_port modes and options that are not specific to HTTP and
 	HTTPS may also work.
+	Among the options that are not available for ftp_port:
+	- require-proxy-header
+	- ssl-bump
 DOC_END
 
 NAME: tcp_outgoing_tos tcp_outgoing_ds tcp_outgoing_dscp

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -51,9 +51,10 @@ COMMENT_START
 
 	Units accepted by Squid are:
 		bytes - byte
-		KB - Kilobyte (1024 bytes)
-		MB - Megabyte
-		GB - Gigabyte
+		KB - Kilobyte (2^10, 1'024 bytes)
+		MB - Megabyte (2^20, 1'048'576 bytes)
+		GB - Gigabyte (2^30, 1'073'741'824 bytes)
+	Squid does not yet support KiB, MiB, and GiB unit names.
 
   Values with time units
 

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -478,6 +478,9 @@ DOC_START
 
 	In SMP mode, each worker does nearly all what a single Squid daemon
 	does (e.g., listen on http_port and forward HTTP requests).
+
+	Changing the number of workers requires a restart: Squid warns about but
+	otherwise ignores attempts to change this setting via reconfiguration.
 DOC_END
 
 NAME: cpu_affinity_map

--- a/src/clients/Client.cc
+++ b/src/clients/Client.cc
@@ -1028,6 +1028,9 @@ Client::adjustBodyBytesRead(const int64_t delta)
 void
 Client::delayRead()
 {
+    Assure(!waitingForDelayAwareReadChance);
+    waitingForDelayAwareReadChance = true;
+
     using DeferredReadDialer = NullaryMemFunT<Client>;
     AsyncCall::Pointer call = asyncCall(11, 5, "Client::noteDelayAwareReadChance",
                                         DeferredReadDialer(this, &Client::noteDelayAwareReadChance));

--- a/src/clients/Client.h
+++ b/src/clients/Client.h
@@ -194,6 +194,9 @@ protected:
 #endif
     bool receivedWholeRequestBody = false; ///< handleRequestBodyProductionEnded called
 
+    /// whether we are waiting for MemObject::delayRead() to call us back
+    bool waitingForDelayAwareReadChance = false;
+
     /// whether we should not be talking to FwdState; XXX: clear fwd instead
     /// points to a string literal which is used only for debugging
     const char *doneWithFwd = nullptr;

--- a/src/clients/FtpClient.cc
+++ b/src/clients/FtpClient.cc
@@ -907,6 +907,8 @@ Ftp::Client::dataConnection() const
 void
 Ftp::Client::noteDelayAwareReadChance()
 {
+    // TODO: Merge with HttpStateData::noteDelayAwareReadChance()
+    waitingForDelayAwareReadChance = false;
     data.read_pending = false;
     maybeReadVirginBody();
 }

--- a/src/http.h
+++ b/src/http.h
@@ -152,6 +152,9 @@ private:
     /// positive when we read more than we wanted
     int64_t payloadTruncated = 0;
 
+    /// whether we are waiting for our Comm::Read() handler to be called
+    bool waitingForCommRead = false;
+
     /// Whether we received a Date header older than that of a matching
     /// cached response.
     bool sawDateGoBack = false;

--- a/src/http/StateFlags.h
+++ b/src/http/StateFlags.h
@@ -58,7 +58,6 @@ public:
     bool keepalive_broken = false;
     bool abuse_detected = false;
     bool request_sent = false;
-    bool do_next_read = false;
     bool chunked = false;           ///< reading a chunked response; TODO: rename
     bool chunked_request = false;   ///< writing a chunked request
     bool sentLastChunk = false;     ///< do not try to write last-chunk again

--- a/src/ip/QosConfig.cc
+++ b/src/ip/QosConfig.cc
@@ -390,12 +390,13 @@ Ip::Qos::Config::parseConfigLine()
 
         } else if (strncmp(token, "miss=",5) == 0) {
 
-            char *end;
             if (mark) {
+                char *end = nullptr;
                 if (!xstrtoui(&token[5], &end, &markMiss, 0, std::numeric_limits<nfmark_t>::max())) {
                     debugs(3, DBG_CRITICAL, "ERROR: Bad mark miss value " << &token[5]);
                     self_destruct();
                 }
+                Assure(end);
                 if (*end == '/') {
                     if (!xstrtoui(end + 1, nullptr, &markMissMask, 0, std::numeric_limits<nfmark_t>::max())) {
                         debugs(3, DBG_CRITICAL, "ERROR: Bad mark miss mask value " << (end + 1) << ". Using 0xFFFFFFFF instead.");
@@ -405,12 +406,14 @@ Ip::Qos::Config::parseConfigLine()
                     markMissMask = 0xFFFFFFFF;
                 }
             } else {
+                char *end = nullptr;
                 unsigned int v = 0;
                 if (!xstrtoui(&token[5], &end, &v, 0, std::numeric_limits<tos_t>::max())) {
                     debugs(3, DBG_CRITICAL, "ERROR: Bad TOS miss value " << &token[5]);
                     self_destruct();
                 }
                 tosMiss = (tos_t)v;
+                Assure(end);
                 if (*end == '/') {
                     if (!xstrtoui(end + 1, nullptr, &v, 0, std::numeric_limits<tos_t>::max())) {
                         debugs(3, DBG_CRITICAL, "ERROR: Bad TOS miss mask value " << (end + 1) << ". Using 0xFF instead.");

--- a/src/mem/PoolMalloc.cc
+++ b/src/mem/PoolMalloc.cc
@@ -31,6 +31,10 @@ MemPoolMalloc::allocate()
     if (obj) {
         --meter.idle;
         ++countSavedAllocs;
+        if (doZero)
+            (void)VALGRIND_MAKE_MEM_DEFINED(obj, objectSize);
+        else
+            (void)VALGRIND_MAKE_MEM_UNDEFINED(obj, objectSize);
     } else {
         if (doZero)
             obj = xcalloc(1, objectSize);
@@ -52,6 +56,7 @@ MemPoolMalloc::deallocate(void *obj)
     } else {
         if (doZero)
             memset(obj, 0, objectSize);
+        (void)VALGRIND_MAKE_MEM_NOACCESS(obj, objectSize);
         ++meter.idle;
         freelist.push(obj);
     }

--- a/src/servers/Server.cc
+++ b/src/servers/Server.cc
@@ -85,16 +85,25 @@ Server::maybeMakeSpaceAvailable()
         debugs(33, 4, "request buffer full: client_request_buffer_max_size=" << Config.maxRequestBufferSize);
 }
 
+bool
+Server::mayBufferMoreRequestBytes() const
+{
+    // TODO: Account for bodyPipe buffering as well.
+    if (inBuf.length() >= Config.maxRequestBufferSize) {
+        debugs(33, 4, "no: " << inBuf.length() << '-' << Config.maxRequestBufferSize << '=' << (inBuf.length() - Config.maxRequestBufferSize));
+        return false;
+    }
+    debugs(33, 7, "yes: " << Config.maxRequestBufferSize << '-' << inBuf.length() << '=' << (Config.maxRequestBufferSize - inBuf.length()));
+    return true;
+}
+
 void
 Server::readSomeData()
 {
     if (reading())
         return;
 
-    debugs(33, 4, clientConnection << ": reading request...");
-
-    // we can only read if there is more than 1 byte of space free
-    if (Config.maxRequestBufferSize - inBuf.length() < 2)
+    if (!mayBufferMoreRequestBytes())
         return;
 
     typedef CommCbMemFunT<Server, CommIoCbParams> Dialer;
@@ -125,7 +134,16 @@ Server::doClientRead(const CommIoCbParams &io)
      * Plus, it breaks our lame *HalfClosed() detection
      */
 
+    // mayBufferMoreRequestBytes() was true during readSomeData(), but variables
+    // like Config.maxRequestBufferSize may have changed since that check
+    if (!mayBufferMoreRequestBytes()) {
+        // XXX: If we avoid Comm::ReadNow(), we should not Comm::Read() again
+        // when the wait is over; resume these doClientRead() checks instead.
+        return; // wait for noteMoreBodySpaceAvailable() or a similar inBuf draining event
+    }
     maybeMakeSpaceAvailable();
+    Assure(inBuf.spaceSize());
+
     CommIoCbParams rd(this); // will be expanded with ReadNow results
     rd.conn = io.conn;
     switch (Comm::ReadNow(rd, inBuf)) {

--- a/src/servers/Server.h
+++ b/src/servers/Server.h
@@ -119,6 +119,9 @@ protected:
     /// abort any pending transactions and prevent new ones (by closing)
     virtual void terminateAll(const Error &, const LogTagsErrors &) = 0;
 
+    /// whether client_request_buffer_max_size allows inBuf.length() increase
+    bool mayBufferMoreRequestBytes() const;
+
     void doClientRead(const CommIoCbParams &io);
     void clientWriteDone(const CommIoCbParams &io);
 

--- a/tools/systemd/squid.service
+++ b/tools/systemd/squid.service
@@ -8,7 +8,7 @@
 [Unit]
 Description=Squid Web Proxy Server
 Documentation=man:squid(8)
-After=network.target network-online.target nss-lookup.target
+After=local-fs.target network.target network-online.target nss-lookup.target
 
 [Service]
 Type=notify


### PR DESCRIPTION
- **Fix typo in 1.6.STABLE22 ChangeLog entry**
- **Fix systemd startup sequence to require active Local Filesystem (#1937)**
- **Annotate PoolMalloc memory in valgrind builds (#1946)**
- **Remove GNU'ism in release notes Makefile (#1959)**
- **Fix syntax error in configure.ac**
- **Bug 5481: Fix GCC v14 build [-Wmaybe-uninitialized] (#1982)**
- **Bug 5091: document that changes to workers require restart (#1980)**
- **Bug 5311: clarify configuration byte units (#1979)**
- **Bug 5093: List http_port params that https_port/ftp_port lack (#1977)**
- **Clarify --enable-ecap failure on missing shared library support (#1968)**
- **Bug 5405: Large uploads fill request buffer and die (#1887)**
- **Bug 5352: Do not get stuck when RESPMOD is slower than read(2) (#1777)**
- **Fix GCC v14 [-Wanalyzer-null-dereference] warnings in Kerberos (#1983)**
- **Portability: remove explicit check for libdl (#1963)**
- **Refactor peerRefreshDNS() to clarify its (void*)1 logic (#1950)**
- **Nil request dereference in ACLExtUser and SourceDomainCheck ACLs (#1931)**
- **Prep for v6.13**
